### PR TITLE
Fix usage of VITE_APL_URL

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -281,7 +281,7 @@ const App = () => {
 
   const fetchData = () => {
     let zoom = Math.round(window.devicePixelRatio * 100);
-    const envUrl =getCurrentUrl()
+    const envUrl = getCurrentUrl()
     const url = URL.parse(envUrl)
 
     const protocol = url.protocol === "https:" ? "wss" : "ws";

--- a/src/components/Grid/GridEdit.jsx
+++ b/src/components/Grid/GridEdit.jsx
@@ -438,7 +438,6 @@ const GridEdit = ({ data }) => {
               backgroundColor: data?.backgroundColor,
               outline: 0,
               textAlign: 'right',
-              paddingRight: '5px',
               paddingRight: '5px'
             }}
           >

--- a/src/components/Image/index.jsx
+++ b/src/components/Image/index.jsx
@@ -13,7 +13,6 @@ const Image = ({ data }) => {
     <div
       id={data?.ID}
       style={{
-        display: Visible == 0 ? 'none' : 'block',
         position: 'absolute',
         top: 0,
         left: 0,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -552,9 +552,15 @@ export const getCurrentUrl = () => {
   const currentUrl = window.location.origin;
   const path = window.location.pathname !== "/" ? window.location.pathname : "";
 
-  if (window.location.hostname === "localhost") {
-    return `http://localhost:22322` + path;
-  } else {
-    return currentUrl + path;
+  if (import.meta.env.VITE_APL_URL) {
+    return import.meta.env.VITE_APL_URL + path;
   }
+
+  if (import.meta.env.DEV) {
+    alert("Please set the VITE_APL_URL environment variable in .env file\n\n"+
+      "For running the APL server with the default port, the .env file need only contain:\n\n"+
+      "VITE_APL_URL=http://localhost:22322/"
+    );
+  }
+  return currentUrl + path;
 };


### PR DESCRIPTION
We are only interested in whether this override is set or not. Using whether we are operating on localhost or 127.0.0.1 is incorrect. There are two modes of usage:

* Via the APL code. This uses one single port for everything, and doesn't care about vite. Only that it has the build artefacts. This is how customers are mostly expected to use the tool.
* Developers who are customising the JS side - they can set the env var and use it so they can load the page via :5173 and then make calls to :22322 (or any other custom port).

Also includes removing a couple of unnecessary warnings that are mistakes in the code, rather than the build being too strict.

----

So:

* VITE_APL_URL overrides everything, this also enables a setup where one might have a local JS instance talking to a remote APL instance.
* If the Vite DEV env var is found, a popup is shown with the exact instructions to populate a .env file.

This works whether accessing through the APL server (which only has the build artefacts) and via vite.